### PR TITLE
Fix MPI related issue

### DIFF
--- a/configs/make.raja.iris
+++ b/configs/make.raja.iris
@@ -30,7 +30,7 @@ HDF5_HOME = /gpfs/jlse-fs0/users/bhomerding/spack/opt/spack/linux-rhel7-haswell/
 #EXTRA_FORT_FLAGS = -qstrict
 
 
-MORE_FLAGS = -DENABLE_MPI_TIMING_BARRIER=1 -DSW4_MANAGED_MPI_BUFFERS=1 -DUSE_DIRECT_INVERSE=1 
+MORE_FLAGS = -DENABLE_MPI_TIMING_BARRIER=1 -DSW4_MANAGED_MPI_BUFFERS=1 -DUSE_DIRECT_INVERSE=1 -DDISABLE_COMM_ASYNC
 #-I ${LAPACK_INC}
 #MORE_LINK_FLAGS = -L /soft/compilers/intel-2019/compilers_and_libraries/linux/mkl/lib/intel64 -L/soft/compilers/intel-2019/compilers_and_libraries/linux/lib/intel64 -limf -lintlc -lsvml -lm -ldl -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lifcore 
 #MORE_LINK_FLAGS = -L/soft/restricted/CNDA/sdk/2020.12.15.1-ats/oneapi/compiler/20210130/linux/compiler/lib/intel64_lin -lirc -mkl -fsycl -Wl,--defsym,main=MAIN__ -fsycl-device-lib=all -lifcore

--- a/src/parallelStuff.C
+++ b/src/parallelStuff.C
@@ -445,7 +445,7 @@ void EW::setupMPICommunications() {
   //   }
 }
 
-#if defined(ENABLE_GPU)
+#if defined(ENABLE_GPU) && !defined(DISABLE_COMM_ASYNC)
 void EW::communicate_array(Sarray& u, int grid) {
   // The async version using either device or managed memory works
   // spectrum-mpi/2018.02.05 on Ray. And it is slower on the Hayward case:
@@ -577,7 +577,7 @@ void EW::communicate_arrays(vector<Sarray>& u) {
   for (int g = 0; g < u.size(); g++) communicate_array(u[g], g);
 }
 
-#if defined(ENABLE_GPU)
+#if defined(ENABLE_GPU) && !defined(DISABLE_COMM_ASYNC)
 void EW::communicate_array_2d(Sarray& u, int g, int k) {
   communicate_array_2d_async(u, g, k);
   return;
@@ -648,7 +648,7 @@ void EW::communicate_array_2d(Sarray& u, int g, int k) {
   }
 }
 #endif  // if defined(ENABLE_GPU)
-#if defined(ENABLE_GPU)
+#if defined(ENABLE_GPU) && !defined(DISABLE_COMM_ASYNC)
 void EW::communicate_array_2d_ext(Sarray& u) {
   communicate_array_2d_ext_async(u);
   return;

--- a/src/sycl_policies.h
+++ b/src/sycl_policies.h
@@ -415,7 +415,7 @@ using INJ_POL_ASYNC =
     RAJA::KernelPolicy<
       RAJA::statement::SyclKernel<
         RAJA::statement::For<0, RAJA::sycl_global_2<4>,      // k
-          RAJA::statement::For<1, RAJA::sycl_global_1<16>,    // j
+          RAJA::statement::For<1, RAJA::sycl_global_1<4>,    // j
             RAJA::statement::For<2, RAJA::sycl_global_0<16>, // i
               RAJA::statement::Lambda<0>
             >


### PR DESCRIPTION
- Add a "DISABLE_COMM_ASYNC" flag to use non-async MPI send/recv so sw4 runs fine with MPI on Iris.
- Remove RAJA directives in CurvilinearInterface2::communicate_array for curvilinear tests to run.
- Change a sycl policy to stay under the 256 work-group limit.

Currently passes 19/20 tests, failed gausshill-att-1.in